### PR TITLE
[98] Add area icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ For `tap_action` options, see https://www.home-assistant.io/dashboards/actions/.
   background_color: yellow # a color name, rgb hex or rgba function when an image is not provided (optional)
   camera_image: camera.living_room # a camera entity to use as background (optional)
   camera_view: 'auto' # auto, live (optional)
+  icon: mdi:sofa
+  show_area_icon: true # boolean (optional), default true
   shadow: true # Draws a drop shadow on icons (optional)
   hide_unavailable: false # Hide unavailable entities (optional)
   state_color: true # enable or disable HA colors for all entities

--- a/src/minimalistic-area-card.ts
+++ b/src/minimalistic-area-card.ts
@@ -218,7 +218,7 @@ class MinimalisticAreaCard extends LitElement {
             </div>` : null}
 
             <div class="box">
-                <div class="card-header">${this.config.title}</div>
+                <div class="card-header">${this.renderAreaIcon(this.config)}${this.config.title}</div>
                 <div class="sensors">
                     ${this._entitiesSensor.map((entityConf) => this.renderEntity(entityConf, true, true))}
                 </div>
@@ -229,6 +229,15 @@ class MinimalisticAreaCard extends LitElement {
             </div>
         </ha-card>
     `;
+    }
+
+    renderAreaIcon(areaConfig: MinimalisticAreaCardConfig) {
+        if (getOrDefault(areaConfig.icon, "").trim().length == 0 || !getOrDefault(areaConfig.show_area_icon, true)) {
+            return ""
+        }
+        return html`
+        <ha-icon icon=${ifDefined(areaConfig.icon)}></ha-icon>
+        `;
     }
 
     renderEntity(
@@ -682,6 +691,10 @@ class MinimalisticAreaCard extends LitElement {
       }
     `;
     }
+}
+
+function getOrDefault(value: any, defaultValue) : any{
+   return value == undefined ? defaultValue : value
 }
 
 customElements.define(cardType, MinimalisticAreaCard);

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,8 @@ export interface MinimalisticAreaCardConfig extends LovelaceCardConfig {
   camera_view?: "auto" | "live";
   background_color?: string;
   hide_unavailable?: boolean;
+  icon?: string;
+  show_area_icon?: boolean;
   entities?: Array<EntityConfig | string>;
   tap_action?: ActionConfig;
   hold_action?: ActionConfig;


### PR DESCRIPTION
Example:

```yaml
type: custom:minimalistic-area-card
title: Living room
area: living_room
icon: mdi:sofa
show_icon: true
hide_unavailable: false
shadow: false
tap_action:
  action: navigate
  navigation_path: /dashboard-mobile/living-room
entities:
  - sensor.living_room_climate_temperature
  - sensor.living_room_climate_humidity
  - climate.livingroom_thermostat_thermostat
  - light.toilet_ventilator_light
  - entity: light.stairs_leds
    icon: mdi:stairs
    tap_action:
      action: more-info
  - entity: binary_sensor.main_door_opening
    icon: mdi:door
    state_color: false
    state:
      - value: 'on'
        icon: mdi:door-open
      - value: 'off'
        icon: mdi:door
```
<img width="246" alt="image" src="https://github.com/user-attachments/assets/ef233e09-95d0-4420-a055-a46940ddb00f">
