### PR TITLE
[fix] Ignore null and undefined as templates

### DIFF
--- a/src/minimalistic-area-card.ts
+++ b/src/minimalistic-area-card.ts
@@ -169,6 +169,9 @@ class MinimalisticAreaCard extends LitElement {
     }
 
     _parseTemplatedEntities(obj) {
+        if (obj == null || obj == undefined) {
+            return;
+        }
         const type = typeof obj;
         if (type == 'object') {
             Object.keys(obj).forEach(key => {


### PR DESCRIPTION
This should not be parsed.