### PR TITLE
Add entity name as css class

### DIFF
--- a/src/minimalistic-area-card.ts
+++ b/src/minimalistic-area-card.ts
@@ -387,7 +387,7 @@ export class MinimalisticAreaCard extends LitElement implements LovelaceCard {
     }
 
     return html`
-      <div class="wrapper">
+      <div class="wrapper ${entityConf.entity.replace('.', '_')}">
         <ha-icon-button
           @action=${this._handleEntityAction}
           .actionHandler=${actionHandler({


### PR DESCRIPTION
This change allows customisation like:
```yaml
card_mod:
  style: |
    .sensors .sensor_living_room_climate_humidity {
      background-color: red;
    }

```
this example sets background-color to red for the entity sensor.living_room_climate_humidity in the sensor area.