### PR TITLE
[fix] Use entity level hide settings as default it state overrides.

### DIFF
--- a/src/minimalistic-area-card.ts
+++ b/src/minimalistic-area-card.ts
@@ -379,7 +379,7 @@ export class MinimalisticAreaCard extends LitElement implements LovelaceCard {
       if (stateConfig) {
         icon = this._getOrDefault(entityId, stateConfig.icon, entityConf.icon);
         color = this._getOrDefault(entityId, stateConfig.color, entityConf.color);
-        hide = this._getOrDefault(entityId, stateConfig.hide, false);
+        hide = this._getOrDefault(entityId, stateConfig.hide, hide);
       }
     }
     if (hide) {


### PR DESCRIPTION
Fixes https://github.com/LesTR/homeassistant-minimalistic-area-card/issues/92.