### PR TITLE
[feature] Add operators to state overrides.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,17 +68,36 @@ For `tap_action` options, see https://www.home-assistant.io/dashboards/actions/.
           icon: mdi:door-closed
 ```
 
-State based settings:
+## State based overrides
+
+Example:
 
 ```yaml
 state: # array of values
   - value: value # state value to match
+    operator: '==' # optinal(default ==) - See state operators for details
     icon: mdi:my-icon" # entity icon used when state match
     color: color # color used when state match
     hide: false # Default false, conditionally hide the entity when state match given value
 ```
 
-## Templating support (experimental)
+### State operators
+
+The order of your elements in the `state` object matters. The first one which is `true` will match. This copied the functionality from [button-card](https://github.com/custom-cards/button-card).
+
+|  Operator  | `value` example | Description                                                                                                                                                                           |
+| :--------: | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    `<`     | `5`             | Current state is inferior to `value`                                                                                                                                                  |
+|    `<=`    | `4`             | Current state is inferior or equal to `value`                                                                                                                                         |
+|    `==`    | `42` or `'on'`  | **This is the default if no operator is specified.** Current state is equal (`==` javascript) to `value`                                                                              |
+|    `>=`    | `32`            | Current state is superior or equal to `value`                                                                                                                                         |
+|    `>`     | `12`            | Current state is superior to `value`                                                                                                                                                  |
+|    `!=`    | `'normal'`      | Current state is not equal (`!=` javascript) to `value`                                                                                                                               |
+|  `regex`   | `'^norm.*$'`    | `value` regex applied to current state does match                                                                                                                                     |
+| `template` |                 | See [templates](#experimental-templating-support) for examples. `value` needs to be a javascript expression which returns a boolean. If the boolean is true, it will match this state |
+| `default`  | N/A             | If nothing matches, this is used                                                                                                                                                      |
+
+## Experimental Templating support
 
 You can use experimental support for templating that allows you to create a dynamic value based on the state or other attribute of any entity.
 Everything inside `${}` is now evaluated as a template.

--- a/src/minimalistic-area-card.ts
+++ b/src/minimalistic-area-card.ts
@@ -37,7 +37,7 @@ import {
 import { HassEntity } from 'home-assistant-js-websocket/dist';
 import { version as pkgVersion } from '../package.json';
 import { customElement } from 'lit/decorators.js';
-import { evalTemplate } from './utils';
+import { evalTemplate, filterStateConfigs } from './utils';
 
 /* eslint no-console: 0 */
 console.info(
@@ -375,7 +375,7 @@ export class MinimalisticAreaCard extends LitElement implements LovelaceCard {
 
     if (entityConf.state !== undefined && entityConf.state.length > 0) {
       const currentState = this.computeStateValue(stateObj, entity);
-      const stateConfig = entityConf.state.filter((i) => i.value == currentState)[0];
+      const stateConfig = filterStateConfigs(entityId, entityConf.state, currentState, this.hass);
       if (stateConfig) {
         icon = this._getOrDefault(entityId, stateConfig.icon, entityConf.icon);
         color = this._getOrDefault(entityId, stateConfig.color, entityConf.color);

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,6 +82,7 @@ export type ExtendedEntityConfig = EntitiesCardEntityConfig & {
 };
 
 export type EntityStateConfig = {
+  operator?: '<' | '<=' | '==' | '>=' | '>' | '!=' | 'regex' | 'template' | 'default';
   value: string;
   icon?: string;
   color?: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { HomeAssistantExt } from './types';
+import { EntityStateConfig, HomeAssistantExt } from './types';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function evalTemplate(entity: string | null, template: string, hass: HomeAssistantExt): any {
@@ -27,4 +27,43 @@ export function evalTemplate(entity: string | null, template: string, hass: Home
     e.name = 'MinimalistAreaCardJSTemplateError';
     throw e;
   }
+}
+
+export function filterStateConfigs(
+  entity: string,
+  config: EntityStateConfig[],
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  currentValue: any,
+  hass: HomeAssistantExt,
+): EntityStateConfig | undefined {
+  let defaultValue;
+  const match = config?.filter((c) => {
+    switch (c.operator?.trim().toLocaleLowerCase() || '==') {
+      case '<':
+        return currentValue < c.value;
+      case '<=':
+        return currentValue <= c.value;
+      case '==':
+        return currentValue == c.value;
+      case '>=':
+        return currentValue >= c.value;
+      case '>':
+        return currentValue > c.value;
+      case '!=':
+        return currentValue != c.value;
+      case 'regex':
+        return String(currentValue).match(c.value) ? true : false;
+      case 'template':
+        return evalTemplate(entity, c.value, hass) == true;
+      case 'default':
+        defaultValue = c;
+        return false;
+      default:
+        return false;
+    }
+  });
+  if (match?.length > 0) {
+    return match[0];
+  }
+  return defaultValue;
 }


### PR DESCRIPTION
Add operators to state overrides.
Now, we can build more detailed state overrides based on ranges, regexes, templates, or specifying the default value.

The default operator is still equal. Now we can use '<' | '<=' | '==' | '>=' | '>' | '!=' | 'regex' | 'template' | 'default';

All operators are covered by unit tests.