### PR TITLE
Rename card to better-minimalistic-area

### DIFF
--- a/.devcontainer/configuration.yaml
+++ b/.devcontainer/configuration.yaml
@@ -2,6 +2,6 @@ default_config:
 lovelace:
   mode: yaml
   resources:
-    - url: http://127.0.0.1:6000/minimalistic-area-card.js
+    - url: http://127.0.0.1:6000/better-minimalistic-area-card.js
       type: module
 demo:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
 
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: 'dist/minimalistic-area-card.js'
-          asset_name: minimalistic-area-card.js
+          file: 'dist/better-minimalistic-area-card.js'
+          asset_name: better-minimalistic-area-card.js
           tag: ${{ github.ref }}
           overwrite: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Minimalistic Area Card
+# Better Minimalistic Area Card
 
 A minimalistic area card to have a control panel of your house on your dashboard. This card will show numeric sensors with its value, and binary sensors with only the icon. Switches and lights will have their own button that you can tap/click to toggle, or tap/click and hold to see detailed information.
 
@@ -8,17 +8,21 @@ A minimalistic area card to have a control panel of your house on your dashboard
 
 ![Sample preview](docs/sample.png)
 
-Please consider sponsoring if you feel that this project is somehow useful to you.
-[![BuyMeCoffee][buymecoffeebadge]][buymecoffee]
+This is a fork of [junalmeida/homeassistant-minimalistic-area-card](https://github.com/junalmeida/homeassistant-minimalistic-area-card), and I would like to thank the original author. The reason for renaming can be found in [issue 128)(https://github.com/LesTR/homeassistant-minimalistic-area-card/issues/128).
+
+## Migration from the original card
+
+- install this one from HACS
+- replace type from `custom:minimalistic-area-card` by `custom:better-minimalistic-area-card`.
 
 ## Options
 
-For entity options, see https://www.home-assistant.io/dashboards/entities/#options-for-entities.
+For entity options, see <https://www.home-assistant.io/dashboards/entities/#options-for-entities>.
 
-For `tap_action` options, see https://www.home-assistant.io/dashboards/actions/.
+For `tap_action` options, see <https://www.home-assistant.io/dashboards/actions/>.
 
 ```yaml
-- type: custom:minimalistic-area-card
+- type: custom:better-minimalistic-area-card
   title: Living Room
   image: /local/img/living-room.jpg #any image file on /config/www or an absolute image url. optional, it uses area image if area is specified. (optional)
   area: living_room # area id of an existing area defined in HA. (optional)
@@ -120,16 +124,11 @@ state : any - state value of given entity or null
 user : CurrentUser - structure represents the currently logged user
 ```
 
-[commits-shield]: https://img.shields.io/github/commit-activity/y/junalmeida/homeassistant-minimalistic-area-card.svg?style=for-the-badge
-[commits]: https://github.com/junalmeida/homeassistant-minimalistic-area-card/commits/main
+[commits-shield]: https://img.shields.io/github/commit-activity/y/lestr/homeassistant-minimalistic-area-card.svg?style=for-the-badge
+[commits]: https://github.com/lestr/homeassistant-minimalistic-area-card/commits/main
 [devcontainer]: https://code.visualstudio.com/docs/remote/containers
-[discord]: https://discord.gg/5e9yvq
-[discord-shield]: https://img.shields.io/discord/330944238910963714.svg?style=for-the-badge
 [forum-shield]: https://img.shields.io/badge/community-forum-brightgreen.svg?style=for-the-badge
 [forum]: https://community.home-assistant.io/c/projects/frontend
 [license-shield]: https://img.shields.io/github/license/junalmeida/homeassistant-minimalistic-area-card.svg?style=for-the-badge
-[maintenance-shield]: https://img.shields.io/maintenance/yes/2021.svg?style=for-the-badge
 [releases-shield]: https://img.shields.io/github/release/junalmeida/homeassistant-minimalistic-area-card.svg?style=for-the-badge
 [releases]: https://github.com/junalmeida/homeassistant-minimalistic-area-card/releases
-[buymecoffee]: https://www.buymeacoffee.com/junalmeida
-[buymecoffeebadge]: https://img.shields.io/badge/buy%20me%20a%20coffee-donate-orange?style=plastic&logo=buymeacoffee

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-  "name": "Minimalistic Area Card",
+  "name": "Better Minimalistic Area Card",
   "render_readme": true,
   "filename": "minimalistic-area-card.js"
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "minimalistic-area-card",
+  "name": "better-minimalistic-area-card",
   "version": "1.2.18",
   "description": "Minimalistic Area Card for Home Assistant",
   "keywords": [
@@ -10,7 +10,7 @@
     "lovelace",
     "custom-cards"
   ],
-  "module": "minimalistic-area-card.js",
+  "module": "better-minimalistic-area-card.js",
   "repository": "git@github.com:junalmeida/homeassistant-minimalistic-area-card.git",
   "author": "Marcos Junior <junalmeida@gmail.com>",
   "license": "MIT",

--- a/rollup.config.dev.mjs
+++ b/rollup.config.dev.mjs
@@ -11,8 +11,8 @@ export default {
   input: ['src/minimalistic-area-card.ts'],
   strictDeprecations: true,
   output: {
-    dir: './dist',
     format: 'es',
+    file: 'dist/better-minimalistic-area-card.js',
     sourcemap: true,
   },
   plugins: [

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -38,8 +38,8 @@ export default [
     input: 'src/minimalistic-area-card.ts',
     strictDeprecations: true,
     output: {
-      dir: 'dist',
       format: 'es',
+      file: 'dist/better-minimalistic-area-card.js',
     },
     plugins: [...plugins],
   },

--- a/src/minimalistic-area-card.ts
+++ b/src/minimalistic-area-card.ts
@@ -786,8 +786,20 @@ export class MinimalisticAreaCard extends LitElement implements LovelaceCard {
     `;
   }
 }
+
+@customElement('minimalistic-area-card')
+export class DepracatedMinimalisticAreaCard extends MinimalisticAreaCard {
+  constructor() {
+    console.warn(
+      "[DEPRECATED] You are using depracated card name 'custom:minimalistic-area-card', please update type to 'custom:better-minimalistic-area-card'. The old name will be removed in 1.3.0",
+    );
+    super();
+  }
+}
+
 declare global {
   interface HTMLElementTagNameMap {
-    'minimalistic-area-card': MinimalisticAreaCard;
+    'minimalistic-area-card': DepracatedMinimalisticAreaCard;
+    'better-minimalistic-area-card': MinimalisticAreaCard;
   }
 }

--- a/test/minimalistic-area-card.test.ts
+++ b/test/minimalistic-area-card.test.ts
@@ -4,7 +4,7 @@ import { Alignment, HomeAssistantExt, MinimalisticAreaCardConfig } from '../src/
 describe('Card test', () => {
   const card: MinimalisticAreaCard = new MinimalisticAreaCard();
   const config: MinimalisticAreaCardConfig = {
-    type: 'custom:minimalistic-area-card',
+    type: 'custom:better-minimalistic-area-card',
     title: 'Terrace',
     area: 'terrace',
     icon: 'mdi:balcony',


### PR DESCRIPTION
This is the first step in fixing https://github.com/LesTR/homeassistant-minimalistic-area-card/issues/128.

The card should work for the new name and also for the old one. The old type is marked as deprecated and will be removed at 1.3.0.