### PR TITLE
Add UI support #50: Introduce simple yaml editor

### DIFF
--- a/rollup.config.dev.mjs
+++ b/rollup.config.dev.mjs
@@ -14,6 +14,7 @@ export default {
     format: 'es',
     file: 'dist/better-minimalistic-area-card.js',
     sourcemap: true,
+    inlineDynamicImports: true,
   },
   plugins: [
     resolve(),

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -40,6 +40,7 @@ export default [
     output: {
       format: 'es',
       file: 'dist/better-minimalistic-area-card.js',
+      inlineDynamicImports: true,
     },
     plugins: [...plugins],
   },

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,144 +1,68 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import { fireEvent, HomeAssistant, LovelaceCardEditor } from '@dermotduffy/custom-card-helpers';
-import { css, CSSResultGroup, html, LitElement, TemplateResult } from 'lit';
-
-import { customElement, property, state } from 'lit/decorators.js';
+import { fireEvent, HomeAssistant, LovelaceCardConfig, LovelaceCardEditor } from '@dermotduffy/custom-card-helpers';
+import { css, html, LitElement, TemplateResult } from 'lit';
 import { MinimalisticAreaCardConfig } from './types';
+import { customElement, property, query, state } from 'lit/decorators.js';
 
-@customElement('boilerplate-card-editor')
-export class BoilerplateCardEditor extends LitElement implements LovelaceCardEditor {
-  @property({ attribute: false }) public hass?: HomeAssistant;
+@customElement('better-minimalistic-area-card-editor')
+export class BetterMinimalisticAreaCardEditor extends LitElement implements LovelaceCardEditor {
+  @property({ attribute: false }) public hass?: HomeAssistant | undefined;
+  @state() private config!: MinimalisticAreaCardConfig;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  @query('ha-yaml-editor') _yamlEditor?: any;
 
-  @state() private _config?: MinimalisticAreaCardConfig;
+  private yamlChange = false; // true if the change came through the yaml editor
 
-  @state() private _helpers?: any;
-
-  private _initialized = false;
-
-  public setConfig(config: MinimalisticAreaCardConfig): void {
-    this._config = config;
-
-    this.loadCardHelpers();
-  }
-
-  protected shouldUpdate(): boolean {
-    if (!this._initialized) {
-      this._initialize();
+  setConfig(config: LovelaceCardConfig): void {
+    this.config = config;
+    if (!this.yamlChange) {
+      // YAML was changed externally, so update the editor
+      this._yamlEditor?.setValue(config);
     }
-
-    return true;
-  }
-
-  get _name(): string {
-    return this._config?.name || '';
-  }
-
-  get _entity(): string {
-    return this._config?.entity || '';
-  }
-
-  get _area(): string {
-    return this._config?.area || '';
-  }
-
-  get _show_warning(): boolean {
-    return this._config?.show_warning || false;
-  }
-
-  get _show_error(): boolean {
-    return this._config?.show_error || false;
+    this.yamlChange = false;
   }
 
   protected render(): TemplateResult | void {
-    if (!this.hass || !this._helpers) {
-      return html``;
-    }
-
-    // You can restrict on domain type
-    const entities = Object.keys(this.hass.states);
-
+    if (!this.config) return html`loading...`;
     return html`
-      <mwc-select
-        naturalMenuWidth
-        fixedMenuPosition
-        label="Entity (Required)"
-        .configValue=${'entity'}
-        .value=${this._entity}
-        @selected=${this._valueChanged}
-        @closed=${(ev) => ev.stopPropagation()}
-      >
-        ${entities.map((entity) => {
-          return html`<mwc-list-item .value=${entity}>${entity}</mwc-list-item>`;
-        })}
-      </mwc-select>
-      <mwc-textfield
-        label="Name (Optional)"
-        .value=${this._name}
-        .configValue=${'name'}
-        @input=${this._valueChanged}
-      ></mwc-textfield>
-      <mwc-formfield .label=${`Toggle warning ${this._show_warning ? 'off' : 'on'}`}>
-        <mwc-switch
-          .checked=${this._show_warning !== false}
-          .configValue=${'show_warning'}
-          @change=${this._valueChanged}
-        ></mwc-switch>
-      </mwc-formfield>
-      <mwc-formfield .label=${`Toggle error ${this._show_error ? 'off' : 'on'}`}>
-        <mwc-switch
-          .checked=${this._show_error !== false}
-          .configValue=${'show_error'}
-          @change=${this._valueChanged}
-        ></mwc-switch>
-      </mwc-formfield>
+      <div class="instructions">
+        For instructions, visit the
+        <a href="https://github.com/LesTR/homeassistant-minimalistic-area-card" target="_blank"
+          >Better Minimalistic Area Card Examples and Docs</a
+        >.
+      </div>
+      <div class="yaml-editor">
+        <ha-yaml-editor
+          .defaultValue=${this.config}
+          autofocus
+          .hass=${this.hass}
+          @value-changed=${this._handleYAMLChanged}
+          @keydown=${this._ignoreKeydown}
+          dir="ltr"
+        ></ha-yaml-editor>
+      </div>
     `;
   }
 
-  private _initialize(): void {
-    if (this.hass === undefined) return;
-    if (this._config === undefined) return;
-    if (this._helpers === undefined) return;
-    this._initialized = true;
+  private _ignoreKeydown(ev: KeyboardEvent) {
+    ev.stopPropagation();
   }
 
-  private async loadCardHelpers(): Promise<void> {
-    this._helpers = await (window as any).loadCardHelpers();
+  private _handleYAMLChanged(ev: CustomEvent) {
+    ev.stopPropagation();
+    const config = ev.detail.value;
+    if (ev.detail.isValid) {
+      this.yamlChange = true;
+      this.config = config;
+      fireEvent(this, 'config-changed', { config: this.config });
+    }
   }
 
-  private _valueChanged(ev): void {
-    if (!this._config || !this.hass) {
-      return;
+  static styles = css`
+    .instructions {
+      margin-bottom: 8px;
     }
-    const target = ev.target;
-    if (this[`_${target.configValue}`] === target.value) {
-      return;
-    }
-    if (target.configValue) {
-      if (target.value === '') {
-        const tmpConfig = { ...this._config };
-        delete tmpConfig[target.configValue];
-        this._config = tmpConfig;
-      } else {
-        this._config = {
-          ...this._config,
-          [target.configValue]: target.checked !== undefined ? target.checked : target.value,
-        };
-      }
-    }
-    fireEvent(this, 'config-changed', { config: this._config });
-  }
-
-  static styles: CSSResultGroup = css`
-    mwc-select,
-    mwc-textfield {
-      margin-bottom: 16px;
-      display: block;
-    }
-    mwc-formfield {
-      padding-bottom: 8px;
-    }
-    mwc-switch {
-      --mdc-theme-secondary: var(--switch-checked-color);
+    .instructions a {
+      color: var(--mdc-theme-primary, #6200ee);
     }
   `;
 }

--- a/src/minimalistic-area-card.ts
+++ b/src/minimalistic-area-card.ts
@@ -195,6 +195,12 @@ export class MinimalisticAreaCard extends LitElement implements LovelaceCard {
       });
     }
   }
+
+  public static async getConfigElement() {
+    await import('./editor');
+    return document.createElement('better-minimalistic-area-card-editor');
+  }
+
   // The user supplied configuration. Throw an exception and Home Assistant
   // will render an error card.
   public setConfig(config: MinimalisticAreaCardConfig): void {


### PR DESCRIPTION
This adds a simple YAML editor. It's not perfect, but now we have support for setting visibility and layout via UI.

This will be improved in the future.

<img width="782" alt="image" src="https://github.com/user-attachments/assets/249f0815-0659-4f4a-a2f0-26a8595325cc" />
