### PR TITLE
[feature] Support for plant domain in templates and mark them as sensors

### DIFF
--- a/src/minimalistic-area-card.ts
+++ b/src/minimalistic-area-card.ts
@@ -49,7 +49,7 @@ console.info(
 );
 
 const STATE_NOT_RUNNING = 'NOT_RUNNING';
-const SENSORS = ['sensor', 'binary_sensor'];
+const SENSORS = ['sensor', 'binary_sensor', 'plant'];
 const DOMAINS_TOGGLE = ['fan', 'input_boolean', 'light', 'switch', 'group', 'automation', 'humidifier'];
 
 const createEntityNotFoundWarning = (hass, entityId) =>
@@ -91,6 +91,7 @@ export class MinimalisticAreaCard extends LitElement implements LovelaceCard {
     'siren',
     'scene',
     'todo',
+    'plant',
   ];
   private _templatedEntityNameRegexp = RegExp(`["']((${this._domainsInTemplates.join('|')})[.][a-z_]+)["']`, 'gmsid');
   private configChanged = true;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,5 @@
 import { html } from 'lit';
 import { cardType, cssCardVariablesPrefix, EntityStateConfig, HomeAssistantExt, StyleOptions } from './types';
-import { styleMap } from 'lit-html/directives/style-map.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function evalTemplate(entity: string | null | undefined, template: string, hass: HomeAssistantExt): any {


### PR DESCRIPTION
Add support for [plant](https://www.home-assistant.io/integrations/plant/) domain.