### PR TITLE
[feature] Make buttons icon size configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ For `tap_action` options, see <https://www.home-assistant.io/dashboards/actions/
     sensors_icon_size: 18px #Override size for the icons in sensors area (optional, default 18px)
     sensors_button_size: 32px #Override the clickable area on icons in sensors area (optional, default 32px)
     buttons_color: blue #Override the color for buttons (optional)
+    buttons_icon_size: 24px #Override size for the icons in buttons area (optional, default 24px)
+    buttons_button_size: 48px #Override the clickable area on icons in buttons area (optional, default 48px)
     background_color: yellow # a color name, rgb hex or rgba function when an image is not provided (optional)
     shadow_color: grey # a color name, rgb hex or rgba function for shadow when enabled
   align:
@@ -149,10 +151,12 @@ Templates supports a cople of function which can be used in templates. For concr
 ### CSS variables
 
 - `--ha-better-minimalistic-area-card-color` - configure color for text, sensors, buttons and state values
-- `--ha-better-minimalistic-area-card-sensors-color` - configure color for sensors and state values in the sensor area
-- `--ha-better-minimalistic-area-card-sensors-icon-size` - configure size for the icons in the sensor area (default 18px)
-- `--ha-better-minimalistic-area-card-sensors-button-size` - configure clickable size on icons in the sensor area (default 32px)
-- `--ha-better-minimalistic-area-card-buttons-color` - configure color for buttons and state values in the button area
+- `--ha-better-minimalistic-area-card-sensors-color` - configure color for sensors and state values in the sensors area
+- `--ha-better-minimalistic-area-card-sensors-icon-size` - configure size for the icons in the sensors area (default 18px)
+- `--ha-better-minimalistic-area-card-sensors-button-size` - configure clickable size on icons in the sensors area (default 32px)
+- `--ha-better-minimalistic-area-card-buttons-icon-size` - configure size for the icons in the buttons area (default 24px)
+- `--ha-better-minimalistic-area-card-buttons-button-size` - configure clickable size on icons in the buttons area (default 48px)
+- `--ha-better-minimalistic-area-card-buttons-color` - configure color for buttons and state values in the buttons area
 - `--ha-better-minimalistic-area-card-shadow-color` - configure color of shadow (when enabled)
 
 [license-shield]: https://img.shields.io/github/license/lestr/homeassistant-minimalistic-area-card.svg?style=for-the-badge

--- a/src/minimalistic-area-card.ts
+++ b/src/minimalistic-area-card.ts
@@ -837,13 +837,16 @@ export class MinimalisticAreaCard extends LitElement implements LovelaceCard {
         text-align: center;
       }
 
-      .box .buttons ha-icon-button {
-        margin-left: -8px;
-        margin-right: -6px;
-      }
       .box .sensors ha-icon-button {
         --mdc-icon-size: var(--ha-better-minimalistic-area-card-sensors-icon-size, 18px);
-        --mdc-icon-button-size: var(--ha-better-minimalistic-area-card-button-size, 32px);
+        --mdc-icon-button-size: var(--ha-better-minimalistic-area-card-sensors-button-size, 32px);
+      }
+
+      .box .buttons ha-icon-button {
+        --mdc-icon-size: var(--ha-better-minimalistic-area-card-buttons-icon-size, 24px);
+        --mdc-icon-button-size: var(--ha-better-minimalistic-area-card-buttons-button-size, 48px);
+        margin-left: -8px;
+        margin-right: -6px;
       }
 
       .box .wrapper {

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,8 @@ export interface StyleOptions {
   sensors_color?: string;
   sensors_icon_size?: string;
   sensors_button_size?: string;
+  buttons_icon_size?: string;
+  buttons_button_size?: string;
   buttons_color?: string;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -184,6 +184,8 @@ export function buildCssVariables(
     { key: 'sensors_color', ccs: `${cssCardVariablesPrefix}sensors-color` },
     { key: 'sensors_icon_size', ccs: `${cssCardVariablesPrefix}sensors-icon-size` },
     { key: 'sensors_button_size', ccs: `${cssCardVariablesPrefix}sensors-button-size` },
+    { key: 'buttons_icon_size', ccs: `${cssCardVariablesPrefix}buttons-icon-size` },
+    { key: 'buttons_button_size', ccs: `${cssCardVariablesPrefix}buttons-button-size` },
     { key: 'buttons_color', ccs: `${cssCardVariablesPrefix}buttons-color` },
     { key: 'shadow_color', ccs: `${cssCardVariablesPrefix}shadow-color` },
   ];

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -200,6 +200,8 @@ describe('Verify CSS variables', () => {
     { key: 'sensors_color', variableName: `${cssCardVariablesPrefix}sensors-color`, value: 'red' },
     { key: 'sensors_icon_size', variableName: `${cssCardVariablesPrefix}sensors-icon-size`, value: '16px' },
     { key: 'sensors_button_size', variableName: `${cssCardVariablesPrefix}sensors-button-size`, value: '16px' },
+    { key: 'buttons_icon_size', variableName: `${cssCardVariablesPrefix}buttons-icon-size`, value: '24px' },
+    { key: 'buttons_button_size', variableName: `${cssCardVariablesPrefix}buttons-button-size`, value: '48px' },
     { key: 'buttons_color', variableName: `${cssCardVariablesPrefix}buttons-color`, value: 'red' },
   ])('convert to variable "%s"', ({ key, variableName, value }) => {
     const cfg = {};


### PR DESCRIPTION
Added two new options into style_config: `buttons_icon_size` and `buttons_button_size`.