### PR TITLE
[hotfix] Resolve eslint errors

### DIFF
--- a/src/action-handler-directive.ts
+++ b/src/action-handler-directive.ts
@@ -2,12 +2,12 @@ import { noChange } from 'lit';
 import { AttributePart, directive, Directive, DirectiveParameters } from 'lit/directive.js';
 
 import { fireEvent } from '@dermotduffy/custom-card-helpers';
-import { ActionHandlerDetail, ActionHandlerOptions } from '@dermotduffy/custom-card-helpers/dist/types';
+import { ActionHandlerDetail, ActionHandlerOptions } from '@dermotduffy/custom-card-helpers';
 import { cardType } from './types';
 
 const isTouch = 'ontouchstart' in window || navigator.maxTouchPoints > 0 || navigator.maxTouchPoints > 0;
 
-interface ActionHandler extends HTMLElement {
+interface ActionHandlerInterface extends HTMLElement {
   holdTime: number;
   bind(element: Element, options): void;
 }
@@ -21,7 +21,7 @@ declare global {
   }
 }
 
-class ActionHandler extends HTMLElement implements ActionHandler {
+class ActionHandler extends HTMLElement implements ActionHandlerInterface {
   public holdTime = 500;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/minimalistic-area-card.ts
+++ b/src/minimalistic-area-card.ts
@@ -13,7 +13,7 @@ import {
   NumberFormat,
   numberFormatToLocale,
   round,
-} from '@dermotduffy/custom-card-helpers/dist'; // This is a community maintained npm module with common helper functions/types. https://github.com/custom-cards/custom-card-helpers
+} from '@dermotduffy/custom-card-helpers'; // This is a community maintained npm module with common helper functions/types. https://github.com/custom-cards/custom-card-helpers
 import { css, CSSResultGroup, html, LitElement, nothing, PropertyValues } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ import {
   LovelaceCardEditor,
   EntitiesCardEntityConfig,
   STATES_OFF as STATES_OFF_HELPER,
-} from '@dermotduffy/custom-card-helpers/dist';
+} from '@dermotduffy/custom-card-helpers';
 import { name } from '../package.json';
 declare global {
   interface HTMLElementTagNameMap {


### PR DESCRIPTION
Some rules get enabled by default and result to errors in build. This should fix them.

Example:
```
/home/runner/work/homeassistant-minimalistic-area-card/homeassistant-minimalistic-area-card/src/action-handler-directive.ts
Error:   10:11  error  Unsafe declaration merging between classes and interfaces  @typescript-eslint/no-unsafe-declaration-merging
Error:   24:7   error  Unsafe declaration merging between classes and interfaces  @typescript-eslint/no-unsafe-declaration-merging
```