### PR TITLE
Removed resetting show_area_icon to true

### DIFF
--- a/src/minimalistic-area-card.ts
+++ b/src/minimalistic-area-card.ts
@@ -119,9 +119,6 @@ export class MinimalisticAreaCard extends LitElement implements LovelaceCard {
           this.areaEntities = MinimalisticAreaCard.findAreaEntities(this.hass, area.area_id);
           if (!this.config.icon) {
             this.config.icon = area.icon;
-          } else {
-            // Backward compatibility
-            this.config.show_area_icon = true;
           }
         } else {
           this.area = undefined;


### PR DESCRIPTION
This PR removes the else branch that resets visibility of the area icon to true upon area card refresh.
When the area card is rendered for the second time via performUpdate() because, for example, an entity button in the card was clicked, the else branch that is removed in this PR mistakenly makes the area icon visible, overriding both the default (false) and any explicit setting of show_area_icon to false.