### PR TITLE
[399] Fix show_are_icon overriding

### DIFF
--- a/src/minimalistic-area-card.ts
+++ b/src/minimalistic-area-card.ts
@@ -117,12 +117,13 @@ export class MinimalisticAreaCard extends LitElement implements LovelaceCard {
         if (area) {
           this.area = area;
           this.areaEntities = MinimalisticAreaCard.findAreaEntities(this.hass, area.area_id);
-          if (!this.config.icon) {
-            this.config.icon = area.icon;
-          } else {
-            // Backward compatibility
-            this.config.show_area_icon = true;
-          }
+          // Set icon from the area (if exists) when missing in the config
+          this.config.icon = getOrDefault(
+            null,
+            this.config.icon,
+            this.hass,
+            getOrDefault(null, area.icon, this.hass, undefined),
+          );
         } else {
           this.area = undefined;
           this.areaEntities = undefined;
@@ -370,15 +371,15 @@ export class MinimalisticAreaCard extends LitElement implements LovelaceCard {
     `;
   }
 
-  private renderAreaIcon(areaConfig: MinimalisticAreaCardConfig) {
+  private renderAreaIcon(config: MinimalisticAreaCardConfig) {
     if (
-      this._getOrDefault(null, areaConfig.icon, '').trim().length == 0 ||
-      !this._getOrDefault(null, areaConfig.show_area_icon, false)
+      this._getOrDefault(null, config.icon, '').trim().length == 0 ||
+      !this._getOrDefault(null, config.show_area_icon, false)
     ) {
       return html``;
     }
 
-    return html` <ha-icon icon=${ifDefined(areaConfig.icon)}></ha-icon> `;
+    return html` <ha-icon icon=${ifDefined(config.icon)}></ha-icon> `;
   }
 
   private renderEntity(entityConf: ExtendedEntityConfig) {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,0 +1,135 @@
+import { html } from 'lit-html';
+import { MinimalisticAreaCard } from '../src/minimalistic-area-card';
+import { HomeAssistantExt, MinimalisticAreaCardConfig } from '../src/types';
+
+describe('area card config tests', () => {
+  const card: MinimalisticAreaCard = new MinimalisticAreaCard();
+  const hass: HomeAssistantExt = {
+    connected: true,
+    areas: {
+      noicon: {
+        area_id: 'no-icon',
+        name: 'Area without icon',
+      },
+      withIcon: {
+        area_id: 'with-icon',
+        name: 'Area with icon',
+        icon: 'some-icon-from-area',
+      },
+    },
+  } as unknown as HomeAssistantExt;
+
+  test.each([
+    {
+      area: 'not-existed',
+      iconInConf: undefined,
+      showIcon: undefined,
+      expectedArea: undefined,
+      expectedIcon: undefined,
+      shouldRenderAreaIcon: false,
+    },
+    {
+      area: 'noicon',
+      iconInConf: undefined,
+      showIcon: undefined,
+      expectedArea: hass.areas.noicon,
+      expectedIcon: undefined,
+      shouldRenderAreaIcon: false,
+    },
+    {
+      area: 'noicon',
+      iconInConf: 'some-icon',
+      showIcon: undefined,
+      expectedArea: hass.areas.noicon,
+      expectedIcon: 'some-icon',
+      shouldRenderAreaIcon: false,
+    },
+    {
+      area: 'noicon',
+      iconInConf: 'overrided-icon',
+      showIcon: undefined,
+      expectedArea: hass.areas.noicon,
+      expectedIcon: 'overrided-icon',
+      shouldRenderAreaIcon: false,
+    },
+    {
+      area: 'withIcon',
+      iconInConf: undefined,
+      showIcon: undefined,
+      expectedArea: hass.areas.withIcon,
+      expectedIcon: 'some-icon-from-area',
+      shouldRenderAreaIcon: false,
+    },
+    {
+      area: 'withIcon',
+      iconInConf: undefined,
+      showIcon: true,
+      expectedArea: hass.areas.withIcon,
+      expectedIcon: 'some-icon-from-area',
+      shouldRenderAreaIcon: true,
+    },
+    {
+      area: 'withIcon',
+      iconInConf: '',
+      showIcon: true,
+      expectedArea: hass.areas.withIcon,
+      expectedIcon: '',
+      shouldRenderAreaIcon: false,
+    },
+    {
+      area: 'noicon',
+      iconInConf: '',
+      showIcon: true,
+      expectedArea: hass.areas.noicon,
+      expectedIcon: '',
+      shouldRenderAreaIcon: false,
+    },
+  ])(
+    'verify option from Area and render areaIcon',
+    ({ area, iconInConf, showIcon, expectedArea, expectedIcon, shouldRenderAreaIcon }) => {
+      const matchResults = (
+        area: string | undefined,
+        iconInConf: string | undefined,
+        showIcon: boolean | undefined,
+        expectedArea: unknown,
+        expectedIcon: string | undefined,
+        shouldRenderAreaIcon: boolean | undefined,
+      ): void => {
+        const conf: MinimalisticAreaCardConfig = {
+          area: area,
+        } as MinimalisticAreaCardConfig;
+
+        if (iconInConf != undefined) {
+          conf.icon = iconInConf;
+        }
+        if (showIcon != undefined) {
+          conf.show_area_icon = showIcon;
+        }
+
+        card.config = conf;
+        card.hass = hass;
+        card['setArea']();
+
+        //matchers
+        expect(card['area']).toBe(expectedArea);
+        expect(card.config.icon).toBe(expectedIcon);
+
+        //call Icon render method
+        const renderAreaIcon = card['renderAreaIcon'](conf);
+
+        if (!shouldRenderAreaIcon) {
+          expect(renderAreaIcon).toStrictEqual(html``);
+          expect(renderAreaIcon.values.length).toBe(0);
+        } else {
+          expect(renderAreaIcon).not.toStrictEqual(html``);
+          expect(renderAreaIcon.values).toContain(expectedIcon);
+        }
+      };
+      matchResults(area, iconInConf, showIcon, expectedArea, expectedIcon, shouldRenderAreaIcon);
+      if (showIcon === undefined) {
+        // default for showIcon should be false => verify the same with false too
+        matchResults(area, iconInConf, false, expectedArea, expectedIcon, false);
+      }
+    },
+  );
+});


### PR DESCRIPTION
The card should always respect the configured value and always use `false` as the default value.

Closes https://github.com/LesTR/homeassistant-minimalistic-area-card/issues/399