### PR TITLE
Use Entity object config new card as default

### DIFF
--- a/src/find-entities.ts
+++ b/src/find-entities.ts
@@ -1,6 +1,6 @@
 import { computeDomain, HomeAssistant } from '@dermotduffy/custom-card-helpers';
 import { HassEntity } from 'home-assistant-js-websocket';
-import { HomeAssistantArea } from './types';
+import { ExtendedEntityConfig, HomeAssistantArea } from './types';
 
 const arrayFilter = (
   // eslint-disable-next-line  @typescript-eslint/no-explicit-any
@@ -37,19 +37,19 @@ const arrayFilter = (
 export const findEntities = (
   hass: HomeAssistant,
   maxEntities: number,
-  entities: string[],
-  entitiesFallback: string[],
+  entities: ExtendedEntityConfig[],
+  entitiesFallback: ExtendedEntityConfig[],
   includeDomains?: string[],
   entityFilter?: (stateObj: HassEntity) => boolean,
-): string[] => {
-  const conditions: Array<(value: string) => boolean> = [];
+): ExtendedEntityConfig[] => {
+  const conditions: Array<(value: ExtendedEntityConfig) => boolean> = [];
 
   if (includeDomains?.length) {
-    conditions.push((eid) => includeDomains.includes(computeDomain(eid)));
+    conditions.push((eid) => includeDomains.includes(computeDomain(eid.entity)));
   }
 
   if (entityFilter) {
-    conditions.push((eid) => hass.states[eid] && entityFilter(hass.states[eid]));
+    conditions.push((eid) => hass.states[eid.entity] && entityFilter(hass.states[eid.entity]));
   }
 
   const entityIds = arrayFilter(entities, conditions, maxEntities);

--- a/src/minimalistic-area-card.ts
+++ b/src/minimalistic-area-card.ts
@@ -67,7 +67,7 @@ export class MinimalisticAreaCard extends LitElement implements LovelaceCard {
   hass!: HomeAssistantExt;
   config!: MinimalisticAreaCardConfig;
   private area?: HomeAssistantArea;
-  private areaEntities?: string[];
+  private areaEntities?: ExtendedEntityConfig[];
   private _domainsInTemplates = [
     'input_([^.]+)',
     '(binary_)?sensor',
@@ -656,7 +656,7 @@ export class MinimalisticAreaCard extends LitElement implements LovelaceCard {
     return getOrDefault(entity, value, this.hass, defaultValue);
   }
 
-  public static findAreaEntities(hass: HomeAssistantExt, area_id: string): Array<string> {
+  public static findAreaEntities(hass: HomeAssistantExt, area_id: string): ExtendedEntityConfig[] {
     const area = hass.areas && hass.areas[area_id];
     const areaEntities =
       hass.entities &&
@@ -664,18 +664,24 @@ export class MinimalisticAreaCard extends LitElement implements LovelaceCard {
       Object.keys(hass.entities)
         .filter(
           (e) =>
-            !hass.entities[e].disabled_by &&
             !hass.entities[e].hidden &&
             hass.entities[e].entity_category !== 'diagnostic' &&
             hass.entities[e].entity_category !== 'config' &&
             (hass.entities[e].area_id === area.area_id ||
               hass.devices[hass.entities[e].device_id || '']?.area_id === area.area_id),
         )
-        .map((x) => x);
-    return areaEntities;
+        .map((x) => MinimalisticAreaCard._mapEntityNameToEntityConfig(x));
+    return areaEntities || [];
   }
 
-  public static getStubConfig(hass: HomeAssistantExt, entities: string[], entitiesFallback: string[]) {
+  private static _mapEntityNameToEntityConfig(name: string): ExtendedEntityConfig {
+    return { entity: name } as ExtendedEntityConfig;
+  }
+
+  public static getStubConfig(hass: HomeAssistantExt, input_entities: string[], input_entitiesFallback: string[]) {
+    const entities = input_entities.map((x) => MinimalisticAreaCard._mapEntityNameToEntityConfig(x));
+    const entitiesFallback = input_entitiesFallback.map((x) => MinimalisticAreaCard._mapEntityNameToEntityConfig(x));
+
     const area = hass.areas && hass.areas[Object.keys(hass.areas)[0]];
     const areaEntities = MinimalisticAreaCard.findAreaEntities(hass, area.area_id);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -117,10 +117,13 @@ export interface EntityRegistryDisplayEntry {
   device_id?: string;
   area_id?: string;
   hidden?: boolean;
+  icon?: string;
   entity_category?: 'config' | 'diagnostic';
   translation_key?: string;
   platform?: string;
   display_precision?: number;
+  has_entity_name?: boolean;
+  labels?: Array<string>;
 }
 
 export const UNAVAILABLE = 'unavailable';
@@ -130,14 +133,7 @@ export const cardType = name;
 export type HomeAssistantExt = HomeAssistant & {
   areas: { [key: string]: HomeAssistantArea };
   entities: {
-    [key: string]: {
-      area_id?: string;
-      entity_id: string;
-      device_id?: string;
-      entity_category?: string;
-      disabled_by?: string;
-      hidden: boolean;
-    };
+    [key: string]: EntityRegistryDisplayEntry;
   };
   devices: { [key: string]: { area_id?: string; disabled_by?: string } };
 };


### PR DESCRIPTION
The original card uses the string name for entities by default, which causes many issues and requires handling two configs in parallel. This change uses the object configuration as the default and simplifies the logic in other methods - strict object everywhere.

This is a first step for adding a visual editor.