### PR TITLE
[FIX] hide should have precedence before hide_unavailable

### DIFF
--- a/src/minimalistic-area-card.ts
+++ b/src/minimalistic-area-card.ts
@@ -434,15 +434,16 @@ export class MinimalisticAreaCard extends LitElement implements LovelaceCard {
         hide_if_unavailable = this._getOrDefault(entityId, stateConfig.hide_unavailable, hide_if_unavailable);
       }
     }
+    const is_unavailable = !stateObj || stateObj.state === UNAVAILABLE;
 
-    if ((!stateObj || stateObj.state === UNAVAILABLE) && !hide_if_unavailable) {
+    if (hide || (is_unavailable && hide_if_unavailable)) {
+      return nothing;
+    } else if (is_unavailable && !hide_if_unavailable) {
       return html`
         <div class="wrapper">
           <hui-warning-element .label=${createEntityNotFoundWarning(this.hass, entityId)}></hui-warning-element>
         </div>
       `;
-    } else if (((!stateObj || stateObj.state === UNAVAILABLE) && hide_if_unavailable) || hide) {
-      return nothing;
     }
 
     const active = stateObj && stateObj.state && STATES_OFF.indexOf(stateObj.state.toString().toLowerCase()) === -1;

--- a/test/minimalistic-area-card.test.ts
+++ b/test/minimalistic-area-card.test.ts
@@ -8,8 +8,10 @@ import {
   ExtendedEntityConfig,
   HomeAssistantExt,
   MinimalisticAreaCardConfig,
+  UNAVAILABLE,
 } from '../src/types';
 import { HassEntity } from 'home-assistant-js-websocket/dist/types';
+import { nothing } from 'lit-html';
 
 describe('Card test', () => {
   const card: MinimalisticAreaCard = new MinimalisticAreaCard();
@@ -25,8 +27,8 @@ describe('Card test', () => {
       navigation_path: '/dashboard-mobile/terrace',
     },
     entities: [
-      'sensor.terrace_climate_temperature_2',
-      'sensor.terrace_climate_humidity_2',
+      'sensor.terrace_climate_temperature',
+      'sensor.terrace_climate_humidity',
       {
         entity: 'sensor.watering_v2_battery',
         show_state: false,
@@ -78,11 +80,24 @@ describe('Card test', () => {
 
   const hass: HomeAssistantExt = {
     connected: true,
+    config: {
+      state: 'RUNNING',
+    },
     areas: {
       terrace: {
         area_id: 'terrace',
         name: 'Terrace',
         picture: '',
+      },
+    },
+    entities: {
+      'binary_sensor.night': {
+        device_id: 'device_binary_sensor_night',
+        area_id: 'terrace',
+      },
+      'sensor.currently_unavalaible': {
+        device_id: 'device_sensor_currently_unavalaible',
+        area_id: 'terrace',
       },
     },
     states: {
@@ -92,6 +107,12 @@ describe('Card test', () => {
       'vacuum.my_vacuum': {
         state: 'docked',
       },
+      'sensor.currently_unavalaible': {
+        state: UNAVAILABLE,
+      },
+    },
+    localize: (key) => {
+      return key;
     },
   } as unknown as HomeAssistantExt;
 
@@ -137,6 +158,55 @@ describe('Card test', () => {
         { entity: 'binary_sensor.night', section: EntitySection.auto },
       ]),
     );
+  });
+
+  test.each([
+    { entity: '' },
+    {
+      entity: 'binary_sensor.night',
+      hide: true,
+    },
+    {
+      entity: 'binary_sensor.night',
+      state: [
+        {
+          operator: 'default',
+          hide: true,
+        },
+      ],
+    },
+    {
+      entity: 'sensor.currently_unavalaible',
+      hide_unavailable: true,
+    },
+    {
+      entity: 'sensor.currently_unavalaible',
+      hide_unavailable: false,
+      hide: true,
+    },
+    {
+      entity: 'sensor.currently_unavalaible',
+      state: [
+        {
+          operator: 'default',
+          hide: true,
+        },
+      ],
+    },
+    {
+      entity: 'sensor.currently_unavalaible',
+      state: [
+        {
+          operator: 'default',
+          hide_unavailable: true,
+        },
+      ],
+    },
+  ])('Verify not rendering entities', (entityConf) => {
+    const conf: ExtendedEntityConfig = {
+      ...entityConf,
+    } as unknown as ExtendedEntityConfig;
+    expect(card['renderEntity'](conf)).toBe(nothing);
   });
 });
 


### PR DESCRIPTION
This fixes the bug where the entity has an override for `hide` (which returns true), but the card renders the warning icon for an unavailable entity.