### PR TITLE
[BUG] Don't render sensor states for null value

### DIFF
--- a/src/minimalistic-area-card.ts
+++ b/src/minimalistic-area-card.ts
@@ -481,7 +481,7 @@ export class MinimalisticAreaCard extends LitElement implements LovelaceCard {
             .color=${color}
           ></state-badge>
         </ha-icon-button>
-        ${isSensor && entityConf.show_state
+        ${currentState != null && isSensor && entityConf.show_state
           ? html`
               <div class="state">
                 ${entityConf.attribute


### PR DESCRIPTION
This should fix https://github.com/LesTR/homeassistant-minimalistic-area-card/issues/440